### PR TITLE
Use --resampleWidth instead of -Z

### DIFF
--- a/pbresize
+++ b/pbresize
@@ -2,5 +2,5 @@
 
 pngpaste /tmp/ss.png
 width=$((`sips -g pixelWidth /tmp/ss.png | cut -s -d ':' -f 2 | cut -c 2-` / 2))
-sips -Z $width /tmp/ss.png
+sips --resampleWidth $width /tmp/ss.png
 impbcopy /tmp/ss.png


### PR DESCRIPTION
According to `man sips`, `-Z` will ensure that the image's width AND height is smaller than the specified value. So `-Z` will break if height is larger than width. `--resampleWidth` is the correct option here.